### PR TITLE
Refactor esg_search_agent to uncomment tool initialization and add me…

### DIFF
--- a/src/esg_search_agent.ts
+++ b/src/esg_search_agent.ts
@@ -14,13 +14,13 @@ const OutputStateAnnotation = Annotation.Root({
   last_content: Annotation<string[]>(),
 });
 
-// const tools = [new TavilySearchResults({ maxResults: 5 })];
+const tools = [new TavilySearchResults({ maxResults: 5 })];
 
-const email = process.env.EMAIL ?? '';
-const password = process.env.PASSWORD ?? '';
-const tools = [
-  new SearchInternetTool({ email, password }),
-];
+// const email = process.env.EMAIL ?? '';
+// const password = process.env.PASSWORD ?? '';
+// const tools = [
+//   new SearchInternetTool({ email, password }),
+// ];
 
 // Define the function that calls the model
 async function callModel(state: typeof InternalStateAnnotation.State) {
@@ -47,7 +47,7 @@ function routeModelOutput(state: typeof InternalStateAnnotation.State) {
   const messages = state.messages;
   const lastMessage: AIMessage = messages[messages.length - 1];
   // If the LLM is invoking tools, route there.
-  if ((lastMessage?.tool_calls?.length ?? 0) > 0) {
+  if ((lastMessage?.tool_calls?.length ?? 0) > 0 && messages.length < 10) {
     return 'tools';
   }
   // Otherwise to the outputModel.


### PR DESCRIPTION
@linancn This pull request includes changes to the `src/esg_search_agent.ts` file to improve the handling of tool invocations and the routing of model output. The most important changes are focused on modifying the conditions for tool invocation and adjusting the list of tools used.

Tool invocation adjustments:

* Modified the condition in the `routeModelOutput` function to limit tool invocations to when there are fewer than 10 messages.

Tool list adjustments:

* Uncommented the `TavilySearchResults` tool initialization and commented out the `SearchInternetTool` initialization to adjust the tools being used.…ssage length check for tool calls