### PR TITLE
Remove message length restriction for tool calls in routeModelOutput function

### DIFF
--- a/src/esg_search_agent.ts
+++ b/src/esg_search_agent.ts
@@ -47,7 +47,7 @@ function routeModelOutput(state: typeof InternalStateAnnotation.State) {
   const messages = state.messages;
   const lastMessage: AIMessage = messages[messages.length - 1];
   // If the LLM is invoking tools, route there.
-  if ((lastMessage?.tool_calls?.length ?? 0) > 0 && messages.length < 10) {
+  if ((lastMessage?.tool_calls?.length ?? 0) > 0) {
     return 'tools';
   }
   // Otherwise to the outputModel.


### PR DESCRIPTION
Eliminate the restriction on the number of messages when routing tool calls in the routeModelOutput function. This change allows for more flexibility in handling tool invocations.