### PR TITLE
Add learning_path to chainState and filter existing nodes in returnGraph

### DIFF
--- a/src/learning_path_sub_agent.ts
+++ b/src/learning_path_sub_agent.ts
@@ -28,6 +28,7 @@ type supabaseElement = {
 const chainState = Annotation.Root({
   content: Annotation<string>(),
   knowledge_point: Annotation<string>(),
+  learning_path: Annotation<{ name: string; id: string }[]>(),
   supabase_auth: Annotation<supabaseElement>(),
   userData: Annotation<userElement>(),
   refData: Annotation<{ content: string; source: string }>(),
@@ -114,14 +115,16 @@ async function returnGraph(state: typeof chainState.State) {
     `;
 
     const result_nodes = await session.run(query_nodes, { list: state.graphData });
-
-    const nodes: { name: string; id: string }[] = result_nodes.records.map((record) => {
-      const node = record.get('n');
-      return {
-        name: node.properties.id,
-        id: node.elementId,
-      };
-    });
+    const existingIds = new Set(state.learning_path.map((node) => node.id));
+    const nodes: { name: string; id: string }[] = result_nodes.records
+      .map((record) => {
+        const node = record.get('n');
+        return {
+          name: node.properties.id,
+          id: node.elementId,
+        };
+      })
+      .filter((node) => !existingIds.has(node.id));
 
     const query_edges = `
       MATCH (a {id: $start_name})


### PR DESCRIPTION
@linancn 

This pull request enhances the handling of learning path data in the `src/learning_path_sub_agent.ts` file by introducing a new annotation for learning paths and ensuring duplicate nodes are filtered out when processing graph data.

### Enhancements to learning path data handling:

* Added a new `learning_path` annotation to the `chainState` object to store an array of learning path nodes, each containing a `name` and an `id`. (`[src/learning_path_sub_agent.tsR31](diffhunk://#diff-8a67ebb988f46dcd1bfddf1cdb83314d172b0041ce5e9ce09ed54d77a153ed12R31)`)

* Updated the `returnGraph` function to filter out nodes with duplicate `id` values by comparing them against the `learning_path` annotation in the state. This ensures that only unique nodes are included in the result. (`[src/learning_path_sub_agent.tsL117-R127](diffhunk://#diff-8a67ebb988f46dcd1bfddf1cdb83314d172b0041ce5e9ce09ed54d77a153ed12L117-R127)`)