### PR TITLE
Update @tiangong-lca/tidas-sdk to version 0.1.18 and add timing logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@langchain/core": "^0.3.55",
     "@langchain/langgraph": "^0.2.71",
     "@langchain/openai": "^0.5.10",
-    "@tiangong-lca/tidas-sdk": "^0.1.15",
+    "@tiangong-lca/tidas-sdk": "^0.1.18",
     "axios": "^1.9.0",
     "langsmith": "^0.3.28",
     "neo4j-driver": "^5.28.1",

--- a/src/lca_ai_suggestion.ts
+++ b/src/lca_ai_suggestion.ts
@@ -1,7 +1,7 @@
 import { suggestData } from '@tiangong-lca/tidas-sdk';
-import { MessagesAnnotation, StateGraph,Annotation } from '@langchain/langgraph';
-import { z } from 'zod';
-import { BaseMessage } from '@langchain/core/messages';
+import { StateGraph,Annotation } from '@langchain/langgraph';
+// import { z } from 'zod';
+// import { BaseMessage } from '@langchain/core/messages';
 
 
 // const inputSchema = z.object({
@@ -55,10 +55,13 @@ const defaultOptions = {
 // console.log(JSON.stringify(defaultOptions));
 
 const suggestDataNode = async (state: typeof InternalStateAnnotation.State): Promise<Partial<typeof OutputStateAnnotation.State>>  => {
+  const timeStart = Date.now();
   const response = await suggestData(state.data, state.dataType, {
     ...defaultOptions,
     ...state.options,
   });
+  const timeEnd = Date.now();
+  console.log(`SuggestDataNode: Time taken: ${timeEnd - timeStart} milliseconds`);
   // console.log('response');
   // console.log(JSON.stringify(response));
   return {  data: response.data, dataType: state.dataType, options: state.options, diffSummary: response.diffSummary, diffHTML: response.diffHTML, success: response.success, error: response.error};


### PR DESCRIPTION
## Summary
- Updated @tiangong-lca/tidas-sdk dependency from version 0.1.15 to 0.1.18
- Added timing logs to suggestDataNode function to track execution time
- Cleaned up unused imports in lca_ai_suggestion.ts

## Changes
- **package.json**: Bumped @tiangong-lca/tidas-sdk to ^0.1.18
- **src/lca_ai_suggestion.ts**: 
  - Added timing measurements (start/end) around suggestData call
  - Added console log to output execution time in milliseconds
  - Commented out unused imports (z from zod, BaseMessage from @langchain/core/messages)