### PR TITLE
chore: add local docpact pre-push gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,0 +1,187 @@
+version: 1
+layout: repo
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 171453290f1c1c319e5d9c47af6622d76e6aa9df
+
+catalog:
+  repos:
+    - id: ai-langgraph-server
+      path: .
+      canonicalRepo: linancn/tiangong-ai-langgraph-server
+      entryDoc: AGENTS.md
+      workflowDocs:
+        - docs/agents/repo-validation.md
+      workspaceIntegrationRequired: true
+
+ownership:
+  domains:
+    - id: repo-governance-and-docs
+      paths:
+        include:
+          - AGENTS.md
+          - README.md
+          - .docpact/config.yaml
+          - docs/agents/**
+          - .github/workflows/ai-doc-lint.yml
+      ownerRepo: ai-langgraph-server
+    - id: runtime-and-operator-surface
+      paths:
+        include:
+          - package.json
+          - langgraph.json
+          - tsconfig.json
+          - .nvmrc
+          - src/**
+          - nginx/**
+          - docker-compose.self-hosted.yml
+          - test.http
+      ownerRepo: ai-langgraph-server
+    - id: local-docpact-push-gate
+      paths:
+        include:
+          - .githooks/**
+          - scripts/docpact-gate.sh
+          - scripts/install-git-hooks.sh
+      ownerRepo: ai-langgraph-server
+
+coverage:
+  include:
+    - AGENTS.md
+    - README.md
+    - .docpact/config.yaml
+    - docs/agents/**
+    - .github/workflows/ai-doc-lint.yml
+    - .githooks/**
+    - scripts/docpact-gate.sh
+    - scripts/install-git-hooks.sh
+    - package.json
+    - langgraph.json
+    - tsconfig.json
+    - .nvmrc
+    - src/**
+    - nginx/**
+    - docker-compose.self-hosted.yml
+    - test.http
+  exclude:
+    - .git/**
+    - .docpact/runs/**
+    - node_modules/**
+    - dist/**
+    - build/**
+    - .venv/**
+    - __pycache__/**
+
+freshness:
+  warn_after_commits: 40
+  warn_after_days: 60
+  critical_after_days: 120
+
+routing:
+  intents:
+    repo-docs:
+      paths:
+        - AGENTS.md
+        - README.md
+        - .docpact/config.yaml
+        - docs/agents/**
+        - .github/workflows/ai-doc-lint.yml
+    runtime:
+      paths:
+        - package.json
+        - langgraph.json
+        - tsconfig.json
+        - .nvmrc
+        - src/**
+        - nginx/**
+        - docker-compose.self-hosted.yml
+        - test.http
+    local-docpact-gate:
+      paths:
+        - .githooks/pre-push
+        - scripts/docpact-gate.sh
+        - scripts/install-git-hooks.sh
+    proof:
+      paths:
+        - docs/agents/repo-validation.md
+        - .github/workflows/ai-doc-lint.yml
+        - .githooks/pre-push
+        - scripts/docpact-gate.sh
+        - scripts/install-git-hooks.sh
+    root-integration:
+      paths:
+        - AGENTS.md
+
+docInventory:
+  include:
+    - AGENTS.md
+    - README.md
+    - .docpact/config.yaml
+    - docs/agents/repo-validation.md
+
+repo:
+  id: ai-langgraph-server
+  owner: ai-langgraph-server
+
+rules:
+  - id: ai-langgraph-server-bootstrap-contract
+    scope: repo
+    repo: ai-langgraph-server
+    triggers:
+      - path: AGENTS.md
+        kind: doc-contract
+      - path: .docpact/config.yaml
+        kind: doc-ai-layer
+      - path: docs/agents/repo-validation.md
+        kind: deep-doc
+      - path: .github/workflows/ai-doc-lint.yml
+        kind: automation
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+    reason: Repo entry guidance, machine-readable routing, validation guidance, and PR docpact enforcement must stay aligned.
+  - id: ai-langgraph-server-runtime-contract
+    scope: repo
+    repo: ai-langgraph-server
+    triggers:
+      - path: package.json
+        kind: runtime-or-docs
+      - path: langgraph.json
+        kind: runtime-or-docs
+      - path: tsconfig.json
+        kind: runtime-or-docs
+      - path: .nvmrc
+        kind: runtime-or-docs
+      - path: src/**
+        kind: runtime-or-docs
+      - path: nginx/**
+        kind: runtime-or-docs
+      - path: docker-compose.self-hosted.yml
+        kind: runtime-or-docs
+      - path: test.http
+        kind: runtime-or-docs
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+    reason: Runtime or operator-surface changes must keep repo entry and validation guidance accurate.
+  - id: ai-langgraph-server-local-docpact-push-gate
+    scope: repo
+    repo: ai-langgraph-server
+    triggers:
+      - path: .githooks/pre-push
+        kind: local-git-hook
+      - path: scripts/docpact-gate.sh
+        kind: local-automation
+      - path: scripts/install-git-hooks.sh
+        kind: local-automation
+    requiredDocs:
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+    reason: Local push documentation governance gates must stay aligned with repo validation guidance and docpact configuration.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+exec "$repo_root/scripts/docpact-gate.sh" "$@"

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,30 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install docpact
+        run: cargo install docpact --version 0.1.4 --force
+
+      - name: Validate docpact config
+        run: docpact validate-config --root . --strict
+
+      - name: Run docpact lint
+        run: >
+          docpact lint
+          --root .
+          --base "${{ github.event.pull_request.base.sha }}"
+          --head "${{ github.event.pull_request.head.sha }}"
+          --mode enforce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+---
+title: ai-langgraph-server AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: ai-langgraph-server
+language: en
+whenToUse:
+  - when routing work from the workspace root into this repository
+  - when deciding validation, ownership, or documentation-governance rules
+  - when changing runtime, operator, or local gate behavior
+whenToUpdate:
+  - when repo ownership or runtime boundaries change
+  - when validation or local gate behavior changes
+  - when docpact governance rules change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - .docpact/config.yaml
+  - docs/agents/**
+  - .github/workflows/ai-doc-lint.yml
+  - .githooks/**
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 171453290f1c1c319e5d9c47af6622d76e6aa9df
+related:
+  - .docpact/config.yaml
+  - docs/agents/repo-validation.md
+---
+
+# ai-langgraph-server AI Working Guide
+
+LangGraph server runtime, agent orchestration, gateway, and local development repository.
+
+## Local Docpact Push Gate
+
+Install the versioned local hook once per checkout:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -1,0 +1,37 @@
+---
+title: ai-langgraph-server Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: ai-langgraph-server
+language: en
+whenToUse:
+  - when selecting local validation commands
+  - when recording proof for documentation-governance changes
+whenToUpdate:
+  - when validation commands or local gate behavior changes
+checkPaths:
+  - docs/agents/repo-validation.md
+  - .docpact/config.yaml
+  - .githooks/pre-push
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 171453290f1c1c319e5d9c47af6622d76e6aa9df
+related:
+  - ../../AGENTS.md
+  - ../../.docpact/config.yaml
+---
+
+# ai-langgraph-server Validation Guide
+
+## Local Docpact Push Gate
+
+Install the versioned local hook once per checkout:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/scripts/docpact-gate.sh
+++ b/scripts/docpact-gate.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+find_docpact() {
+  if [ -n "${DOCPACT_BIN:-}" ] && "$DOCPACT_BIN" --version >/dev/null 2>&1; then
+    printf '%s\n' "$DOCPACT_BIN"
+    return 0
+  fi
+
+  if [ -x "$HOME/.cargo/bin/docpact" ] && "$HOME/.cargo/bin/docpact" --version >/dev/null 2>&1; then
+    printf '%s\n' "$HOME/.cargo/bin/docpact"
+    return 0
+  fi
+
+  if command -v docpact >/dev/null 2>&1; then
+    command -v docpact
+    return 0
+  fi
+
+  echo "docpact was not found. Install it with: cargo install docpact --version 0.1.4 --force" >&2
+  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
+  return 127
+}
+
+docpact_bin="$(find_docpact)"
+current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+head_ref="${DOCPACT_HEAD_REF:-HEAD}"
+base_ref="${DOCPACT_BASE_REF:-origin/main}"
+
+case "$current_branch" in
+  main | master | promote/* | hotfix/* | release/*)
+    if [ -z "${DOCPACT_BASE_REF:-}" ]; then
+      base_ref="origin/main"
+    fi
+    ;;
+esac
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      base_ref="$2"
+      shift 2
+      ;;
+    --head)
+      head_ref="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if ! base_sha="$(git merge-base "$head_ref" "$base_ref" 2>/dev/null)"; then
+  echo "Could not resolve merge-base for $head_ref and $base_ref." >&2
+  echo "Fetch the base ref or rerun with DOCPACT_BASE_REF=<ref>." >&2
+  exit 2
+fi
+
+head_sha="$(git rev-parse "$head_ref")"
+report_path="${TMPDIR:-/tmp}/docpact-gate-$$.json"
+trap 'rm -f "$report_path"' EXIT HUP INT TERM
+
+echo "Running docpact config validation."
+"$docpact_bin" validate-config --root . --strict
+
+echo "Running docpact lint: base=$base_sha head=$head_sha."
+"$docpact_bin" lint --root . --base "$base_sha" --head "$head_sha" --mode enforce --output "$report_path"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push scripts/docpact-gate.sh
+
+echo "Configured git hooks: core.hooksPath=.githooks"


### PR DESCRIPTION
Closes #41
Refs tiangong-lca/workspace#95

## Summary
- add a versioned local pre-push hook that runs docpact before pushing
- add scripts/docpact-gate.sh and scripts/install-git-hooks.sh
- update docpact config and validation guidance for the new local gate

## Key Decisions
- keep this as a lightweight docpact-only local push gate
- do not force heavyweight full validation on every feature-branch push
- write detailed docpact reports to a temporary file to avoid .docpact/runs worktree noise

## Validation
- docpact validate-config --root . --strict
- docpact lint --root . --staged --mode enforce
- scripts/docpact-gate.sh --base origin/main

## Risks / Rollback
Low risk. Revert the hook/script/config changes if local hook installation causes unexpected developer workflow issues.

## Workspace Integration
Requires a later lca-workspace submodule pointer bump tracked by tiangong-lca/workspace#95.
